### PR TITLE
Remove process restriction on game/server processes

### DIFF
--- a/SkipSleep.cs
+++ b/SkipSleep.cs
@@ -9,8 +9,6 @@ using System;
 namespace ModSkipSleepValheim
 {
     [BepInPlugin("com.rinsev.skipsleep", "ModSkipSleepValheim", "1.0.2")]
-    [BepInProcess("valheim.exe")]
-    [BepInProcess("valheim_server.exe")]
     [HarmonyPatch]
     public class Mod : BaseUnityPlugin
     {


### PR DESCRIPTION
Remove process restriction on game/server processes, so it can work with any process running on the system.

This will allow a server running valheim_server.exe, valheim_server2.exe, valheim_server3.exe, etc. processes to all work with this mod.